### PR TITLE
revert unnecessary fixes

### DIFF
--- a/parser/debug/parse.go
+++ b/parser/debug/parse.go
@@ -61,15 +61,15 @@ func Parse(p parser.Interface) (Nodes, error) {
 func RandomParse(p parser.Interface, r Rand, next, down int) (Nodes, error) {
 	nodes := make(Nodes, 0)
 	for {
+		if r.Intn(next) == 0 {
+			break
+		}
 		if err := p.Next(); err != nil {
 			if err == io.EOF {
 				break
 			} else {
 				return nil, err
 			}
-		}
-		if r.Intn(next) == 0 {
-			break
 		}
 		value, err := parser.GetValue(p)
 		if err != nil {

--- a/parser/debug/walk.go
+++ b/parser/debug/walk.go
@@ -83,15 +83,15 @@ func WalkValue(p parser.Value) error {
 // RandomWalk is great for testing that the implemented parser can handle random skipping of parts of the tree.
 func RandomWalk(p parser.Interface, r Rand, next, down int) error {
 	for {
+		if r.Intn(next) == 0 {
+			break
+		}
 		if err := p.Next(); err != nil {
 			if err == io.EOF {
 				break
 			} else {
 				return err
 			}
-		}
-		if r.Intn(next) == 0 {
-			break
 		}
 		if err := WalkValue(p); err != nil {
 			return err


### PR DESCRIPTION
Parsers need to handle multiple calls of Up and Down before a Next is called